### PR TITLE
ticket-027/030: run_log JSON + fix dedup exact-match sin rapidfuzz

### DIFF
--- a/agents/output_agent.py
+++ b/agents/output_agent.py
@@ -1,14 +1,18 @@
 """
-agents/output_agent.py — Exports qualified leads + RunReport to Excel.
+agents/output_agent.py — Exports qualified leads + RunReport to Excel + JSON log.
 
 Responsibilities:
   1. Call ExcelExportTool to generate the .xlsx file.
-  2. Print a Rich table summary to stdout.
-  3. Return the output file path.
+  2. Write run_log_{timestamp}.json with full audit trail.
+  3. Print a Rich table summary to stdout.
+  4. Return the output file path.
 """
 
 from __future__ import annotations
 
+import json
+import re
+from datetime import datetime
 from pathlib import Path
 from typing import Sequence
 
@@ -50,8 +54,60 @@ class OutputAgent:
             filename_prefix=self.config.output_filename,
         )
 
-        self._print_summary(leads, report, out_path)
+        log_path = self._write_run_log(leads, report, out_path)
+        self._print_summary(leads, report, out_path, log_path)
         return out_path
+
+    # ──────────────────────────────────────────────────────────────
+
+    def _write_run_log(
+        self,
+        leads: list[QualifiedLead],
+        report: RunReport,
+        excel_path: str,
+    ) -> str:
+        """Write run_log_{timestamp}.json for audit and reproducibility."""
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        log_filename = f"run_log_{ts}.json"
+        log_path = Path("output") / log_filename
+
+        # Strip API keys from config snapshot
+        config_snapshot = self.config.model_dump()
+        # Sanitise any field that looks like a key/token (extra safety)
+        _KEY_PAT = re.compile(r"(?i)(api_key|secret|token|password)")
+        for k in list(config_snapshot.keys()):
+            if _KEY_PAT.search(k):
+                config_snapshot[k] = "***"
+
+        log_data = {
+            "campaign_name": report.campaign_name,
+            "timestamp": report.timestamp,
+            "duration_seconds": report.duration_seconds,
+            "iterations_used": report.iterations,
+            "config_snapshot": config_snapshot,
+            "report": report.model_dump(),
+            "sources_breakdown": report.sources_breakdown,
+            "leads_per_iteration": report.leads_per_iteration,
+            "error_log": report.error_log,
+            "excel_output": excel_path,
+            "leads_summary": [
+                {
+                    "name": l.name,
+                    "tier": l.tier,
+                    "final_score": l.final_score,
+                    "contact_priority": l.contact_priority,
+                    "source": l.source,
+                }
+                for l in sorted(leads, key=lambda l: l.contact_priority)
+            ],
+        }
+
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "w", encoding="utf-8") as f:
+            json.dump(log_data, f, ensure_ascii=False, indent=2, default=str)
+
+        console.print(f"[dim]📋 Run log → {log_path}[/dim]")
+        return str(log_path)
 
     # ──────────────────────────────────────────────────────────────
 
@@ -60,6 +116,7 @@ class OutputAgent:
         leads: list[QualifiedLead],
         report: RunReport,
         out_path: str,
+        log_path: str = "",
     ) -> None:
         hot = [l for l in leads if l.tier == "HOT"]
         warm = [l for l in leads if l.tier == "WARM"]
@@ -109,3 +166,7 @@ class OutputAgent:
         console.print(
             f"\n[bold green]✅ Excel exportado → [link={out_path}]{out_path}[/link]"
         )
+        if log_path:
+            console.print(
+                f"[bold green]✅ Run log → [link={log_path}]{log_path}[/link]"
+            )


### PR DESCRIPTION
This pull request enhances the `output_agent.py` to add auditability and reproducibility by generating a detailed JSON run log alongside the existing Excel export and summary output. The main change is the addition of a `run_log_{timestamp}.json` file containing an audit trail of each run, including configuration (with sensitive fields sanitized), report details, and a summary of leads. The summary output now also displays the path to this run log.

**Audit logging and output enhancements:**

* Added a `_write_run_log` method to generate a timestamped JSON log (`run_log_{timestamp}.json`) containing campaign, configuration (with sensitive fields masked), report, and leads summary for each run.
* Updated the main `run` method to call `_write_run_log` and pass the log path to the summary printout, ensuring the run log is created and referenced in the output.
* Modified `_print_summary` to display the run log path in the console output, improving traceability for users.

**Documentation and import updates:**

* Updated the module docstring to reflect the new JSON log functionality, and added necessary imports (`json`, `re`, `datetime`).- output_agent.py: genera run_log_{timestamp}.json en output/ con campaign_name, timestamp, duration, config_snapshot (sin API keys), RunReport completo, leads_per_iteration, error_log y leads_summary
- dedup_tool.py: fix critical — exact place_id y phone-prefix match ahora son independientes de rapidfuzz; fuzzy-only hace graceful skip sin dep
- Playwright Chromium v145 instalado y verificado
- 55/55 tests pasando